### PR TITLE
ARI(Notion): toolbar 영역 기능 구현

### DIFF
--- a/ARI/clone_notion/index.html
+++ b/ARI/clone_notion/index.html
@@ -129,10 +129,25 @@
           </div>
 
           <!-- Toolbar -->
-          <div id="toolbar" class="toolbar">Toolbar 영역</div>
+          <div id="toolbar" class="toolbar">
+            <button class="tbtn" data-cmd="bold"><b>B</b></button>
+            <button class="tbtn" data-cmd="italic"><i>i</i></button>
+            <button class="tbtn" data-cmd="underline"><u>U</u></button>
+            <span class="sep"></span>
+            <button class="tbtn" data-format="P">P</button>
+            <button class="tbtn" data-format="H1">H1</button>
+            <button class="tbtn" data-format="H2">H2</button>
+            <button class="tbtn" data-format="H3">H3</button>
+            <span class="sep"></span>
+            <button id="bulletsBtn" class="tbtn">• List</button>
+            <button id="numbersBtn" class="tbtn">1. List</button>
+            <button id="todoBtn" class="tbtn">☐ To-do</button>
+            <button id="codeBtn" class="tbtn">{ }</button>
+            <button id="quoteBtn" class="tbtn">❝ ❞</button>
+          </div>
 
           <!-- Editor -->
-          <div id="editor" class="editor">Editor 영역</div>
+          <div id="editor" class="editor" contenteditable="true"></div>
         </div>
       </main>
     </div>

--- a/ARI/clone_notion/scripts/editor.js
+++ b/ARI/clone_notion/scripts/editor.js
@@ -1,0 +1,48 @@
+document.getElementById("toolbar").addEventListener("click", (e) => {
+  const btn = e.target.closest("button");
+  if (!btn) return;
+  const cmd = btn.dataset.cmd;
+  const fmt = btn.dataset.format;
+  editor.focus();
+
+  if (cmd) {
+    document.execCommand(cmd, false, null);
+    return;
+  }
+
+  if (fmt) {
+    document.execCommand("formatBlock", false, fmt === "P" ? "P" : fmt);
+    return;
+  }
+});
+
+document.getElementById("bulletsBtn").addEventListener("click", () => {
+  editor.focus();
+  document.execCommand("insertUnorderedList");
+});
+
+document.getElementById("numbersBtn").addEventListener("click", () => {
+  editor.focus();
+  document.execCommand("insertOrderedList");
+});
+
+document.getElementById("codeBtn").addEventListener("click", () => {
+  editor.focus();
+  document.execCommand("formatBlock", false, "PRE");
+});
+
+document.getElementById("quoteBtn").addEventListener("click", () => {
+  editor.focus();
+  document.execCommand("formatBlock", false, "BLOCKQUOTE");
+});
+
+document.getElementById("todoBtn").addEventListener("click", () => {
+  const box = document.createElement("div");
+  box.innerHTML = '<label><input type="checkbox"> <span>To-do</span></label>';
+  const sel = window.getSelection();
+  if (!sel.rangeCount) {
+    editor.appendChild(box);
+  } else {
+    sel.getRangeAt(0).insertNode(box);
+  }
+});

--- a/ARI/clone_notion/scripts/main.js
+++ b/ARI/clone_notion/scripts/main.js
@@ -1,450 +1,60 @@
-const collapseBtn = document.querySelector("#collapseBtn");
-const expandBtn = document.querySelector("#expandBtn");
-const app = document.querySelector(".app");
-
-// 사이드바 상태 전환 함수
-function sidebarCollapsed(on) {
-  // 상태 클래스 토글
-  app.classList.toggle("is-collapsed", on);
-  // 접근성 속성 업데이트
-  expandBtn.setAttribute("aria-expanded", !on);
-  collapseBtn.setAttribute("aria-expanded", !on);
-}
-
-collapseBtn.addEventListener("click", () => sidebarCollapsed(true));
-expandBtn.addEventListener("click", () => sidebarCollapsed(false));
-
+// 공용 상수 & 상태
 const STORAGE_KEYS = { SIDEBAR_WIDTH: "notionClone:sidebar-width" };
-const root = document.documentElement;
-const sidebar = document.querySelector("#sidebar");
-const handle = document.querySelector("#resizeHandle");
-
-const MIN_W = 220;
-const MAX_W = 420;
-let isResizing = false;
-const DEFAULT_W = getComputedStyle(root).getPropertyValue("--sidebar-w").trim();
-
-// 초기 너비 복원
-const savedWidth = localStorage.getItem(STORAGE_KEYS.SIDEBAR_WIDTH);
-if (savedWidth) {
-  root.style.setProperty("--sidebar-w", savedWidth);
-}
-
-const clamp = (n, min, max) => Math.min(max, Math.max(min, n));
-const setWidth = (px) => root.style.setProperty("--sidebar-w", `${px}px`);
-let newWidth;
-
-// 드래그 시작
-function onDown(e) {
-  isResizing = true;
-  document.body.style.userSelect = "none";
-  document.body.style.cursor = "ew-resize";
-  e.preventDefault();
-}
-
-// 드래그 중
-function onMove(e) {
-  if (!isResizing) return;
-
-  newWidth = clamp(e.clientX, MIN_W, MAX_W);
-  setWidth(newWidth);
-}
-
-// 드래그 종료
-function onUp() {
-  if (!isResizing) return;
-  isResizing = false;
-
-  document.body.style.userSelect = "";
-  document.body.style.cursor = "";
-
-  localStorage.setItem(STORAGE_KEYS.SIDEBAR_WIDTH, `${newWidth}px`);
-}
-
-// 더블클릭 : 기본값으로 리셋
-handle.addEventListener("dblclick", () => {
-  root.style.setProperty("--sidebar-w", DEFAULT_W);
-  localStorage.setItem(STORAGE_KEYS.SIDEBAR_WIDTH, DEFAULT_W);
-});
-
-handle.addEventListener("mousedown", onDown);
-window.addEventListener("mousemove", onMove);
-window.addEventListener("mouseup", onUp);
-
-let pageSeq = 0;
-const pages = new Map();
-let activePageId = null;
-
-// 새 페이지 데이터 생성하고 pages에 등록
-function createPageData(title = "새 페이지", parentId = null) {
-  const id = "p" + ++pageSeq;
-  const data = { id, title, content: "", parentId };
-  ensureIconFields(data);
-  pages.set(id, data);
-  return data;
-}
-
-// 사이드바 트리에서 활성 노드 표시 관리
-function setActiveNode(node) {
-  docListRoot
-    .querySelectorAll(".tree-node.is-active")
-    .forEach((n) => n.classList.remove("is-active"));
-  node.classList.add("is-active");
-}
-
-const titleInputEl = document.getElementById("titleInput");
-const breadcrumbsEl = document.getElementById("breadcrumbs");
-
-// 페이지에서 제목 변경 시 : 페이지-사이드바-브레드크럼 동기화
-function applyHeaderTitleToState() {
-  const node = getActiveNode();
-  if (!node) return;
-
-  const pid = node.dataset.pageId;
-  const page = pages.get(pid);
-  if (!page) return;
-
-  const newTitle = (titleInputEl.value || "").trim() || "제목 없음";
-  page.title = newTitle;
-  const titleEl = node.querySelector(":scope > .tree-row .doc-title");
-  if (titleEl) titleEl.textContent = newTitle;
-
-  updateBreadcrumbsFromActive();
-}
-
-// 실시간 동기화
-titleInputEl?.addEventListener("input", applyHeaderTitleToState);
-titleInputEl?.addEventListener("blur", applyHeaderTitleToState);
-
-// 메인 영역에 페이지 표시
-function showPage(pageId, node) {
-  const page = pages.get(pageId);
-  if (!page) return;
-
-  activePageId = pageId;
-
-  if (titleInputEl) {
-    titleInputEl.value = page.title;
-    if (typeof autoResize === "function") autoResize(titleInputEl);
-  }
-  ensureIconFields(page);
-  renderHeaderIcon(page.iconType, page.iconValue);
-
-  if (node) setActiveNode(node);
-
-  updateBreadcrumbsFromActive();
-}
-
-const addPageBtn = document.getElementById("actionAddPage");
-const docListRoot = document.getElementById("docListRoot");
-
 const ICONS = {
   open: "./assets/icons/chevron-down-icon.svg",
   close: "./assets/icons/chevron-up-icon.svg",
+  defaultPage: "./assets/icons/page-default-icon.svg",
+  star: "./assets/icons/star-icon.svg",
+  starFill: "./assets/icons/star-fill-icon.svg",
+};
+const SIDEBAR = { MIN_W: 220, MAX_W: 420, CSS_VAR: "--sidebar-w" };
+
+const appState = {
+  pageSeq: 0,
+  pages: new Map(),
+  activePageId: null,
 };
 
-// 새 tree-node 생성
-function createTreeNode(titleOrPage = "새 페이지", depth = 0, parentId = null) {
-  const page =
-    typeof titleOrPage === "string"
-      ? createPageData(titleOrPage, parentId)
-      : titleOrPage;
-
-  ensureIconFields(page);
-  const iconPage =
-    page.iconType === "emoji"
-      ? `<span class="doc-icon-emoji" aria-hidden="true">${page.iconValue}</span>`
-      : `<img src="${
-          page.iconValue || ICON_DEFAULT_SRC
-        }" alt="기본 페이지 아이콘" />`;
-
-  const node = document.createElement("div");
-  node.className = "tree-node";
-  node.dataset.depth = depth;
-  node.dataset.pageId = page.id;
-  node.style.setProperty("--indent", depth);
-
-  node.innerHTML = `
-      <div class="tree-row">
-        <div class="doc-slot">
-          <div class="doc-icon">
-            ${iconPage}
-          </div>
-          <button class="chevron" type="button" aria-label="하위 페이지 토글" data-action="toggle">
-            <img src="${ICONS.close}" alt="접기" />
-          </button>
-        </div>
-        <div class="doc-title">${page.title}</div>
-        <div class="tree-actions">
-          <button class="ghost" type="button" aria-label="더보기" data-action="more">
-            <img src="./assets/icons/ellipsis-small-icon.svg" alt="더보기" />
-          </button>
-          <button class="ghost" type="button" aria-label="하위 페이지 추가" data-action="add-child">
-            <img src="./assets/icons/plus-small-icon.svg" alt="하위 페이지 추가" />
-          </button>
-          <div class="dropdown-menu">
-            <div class="dropdown-list">
-              <button class="dropdown-item" type="button" data-menu="duplicate">
-              <img src="./assets/icons/star-icon.svg" alt="즐겨찾기" />
-              즐겨찾기에 추가</button>
-              <button class="dropdown-item" type="button" data-menu="rename">
-              <img src="./assets/icons/rename-icon.svg" alt="이름 변경" />
-              이름 바꾸기</button>
-              <button class="dropdown-item" type="button" data-menu="delete">
-              <img src="./assets/icons/trash-icon.svg" alt="휴지통" />
-              휴지통으로 이동</button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="tree-children"></div>
-    `;
-  return node;
+// 공용 로직
+export function ensureIconFields(page) {
+  if (!("iconType" in page)) page.iconType = "image";
+  if (!("iconValue" in page)) page.iconValue = ICONS.defaultPage;
+}
+export function createPageData(title = "새 페이지", parentId = null) {
+  const id = "p" + ++appState.pageSeq;
+  const data = { id, title, content: "", parentId };
+  ensureIconFields(data);
+  appState.pages.set(id, data);
+  return data;
+}
+export function getPage(id) {
+  return appState.pages.get(id);
+}
+export function getActivePageId() {
+  return appState.activePageId;
+}
+export function setActivePageId(id) {
+  appState.activePageId = id;
 }
 
-addPageBtn?.addEventListener("click", () => {
-  const page = createPageData("새 페이지");
-  const node = createTreeNode(page, 0);
-  docListRoot.appendChild(node);
-
-  showPage(page.id, node);
-});
-
-function closeDropdown() {
-  docListRoot.querySelectorAll(".dropdown-menu.is-open").forEach((el) => {
-    el.classList.remove("is-open");
-  });
-}
-
-document.addEventListener("click", (e) => {
-  if (e.target.closest(".dropdown-menu, [data-action='more']")) return;
-  closeDropdown();
-});
-
-// 이벤트 위임: 토글/하위 추가/더보기
-docListRoot.addEventListener("click", (e) => {
-  const btn = e.target.closest("[data-action], .chevron, [data-menu]");
-  if (!btn) return;
-
-  const action = btn.dataset.action;
-  const menuAction = btn.dataset.menu;
-  const node = btn.closest(".tree-node");
-  if (!node) return;
-
-  const children = node.querySelector(":scope > .tree-children");
-  const chevronImg = node.querySelector(":scope > .tree-row .chevron img");
-
-  if (action === "add-child") {
-    const depth = (parseInt(node.dataset.depth, 10) || 0) + 1;
-    const parentId = node.dataset.pageId;
-    const childPage = createPageData("새 페이지", parentId);
-
-    const childNode = createTreeNode(childPage, depth, parentId);
-    children.appendChild(childNode);
-
-    node.classList.add("is-open");
-    chevronImg.src = ICONS.open;
-    chevronImg.alt = "펼치기";
-    return;
-  }
-  if (action === "toggle") {
-    const isOpen = node.classList.toggle("is-open");
-    chevronImg.src = isOpen ? ICONS.open : ICONS.close;
-    chevronImg.alt = isOpen ? "펼치기" : "접기";
-    return;
-  }
-
-  if (action === "more") {
-    const actions = node.querySelector(":scope > .tree-row .tree-actions");
-    const menu = actions.querySelector(":scope > .dropdown-menu");
-    menu.classList.toggle("is-open");
-  }
-
-  // 드롭다운: 이름 변경
-  if (menuAction === "rename") {
-    closeDropdown();
-    const titleEl = node.querySelector(":scope > .tree-row .doc-title");
-    const oldTitle = titleEl.textContent;
-
-    const input = document.createElement("input");
-    input.type = "text";
-    input.value = oldTitle;
-    input.className = "rename-input";
-
-    titleEl.replaceWith(input);
-    input.focus();
-
-    const saveRename = () => {
-      const newTitle = input.value.trim() || oldTitle;
-      const newTitleEl = document.createElement("div");
-      newTitleEl.className = "doc-title";
-      newTitleEl.textContent = newTitle;
-      input.replaceWith(newTitleEl);
-
-      const pid = node.dataset.pageId;
-      const page = pages.get(pid);
-      if (page) page.title = newTitle;
-
-      // 활성 페이지면 헤더도 동기화
-      if (activePageId === pid && titleInputEl) {
-        titleInputEl.value = newTitle;
-        if (typeof autoResize === "function") autoResize(titleInputEl);
-      }
-
-      updateBreadcrumbsFromActive();
-    };
-
-    input.addEventListener("blur", saveRename, { once: true });
-    input.addEventListener("keydown", (ev) => {
-      if (ev.key === "Enter") input.blur();
-      if (ev.key === "Escape") {
-        input.value = oldTitle;
-        input.blur();
-      }
-    });
-  }
-});
-
-function getBreadcrumbPath(node) {
-  const path = [];
-  let current = node;
-
-  while (current) {
-    const titleEl = current.querySelector(":scope > .tree-row .doc-title");
-    if (titleEl) path.unshift(titleEl.textContent.trim());
-
-    current = current.closest(".tree-children")?.closest(".tree-node");
-  }
-
-  return path.join(" / ");
-}
-
-// 활성 노드 가져오기
-function getActiveNode() {
-  return (
-    docListRoot.querySelector(".tree-node.is-active") ||
-    (activePageId &&
-      docListRoot.querySelector(`.tree-node[data-page-id="${activePageId}"]`))
-  );
-}
-
-// 활성 노드 기준으로 브레드크럼 텍스트 갱신
-function updateBreadcrumbsFromActive() {
-  const node = getActiveNode();
-  if (!node) return;
-  const path = getBreadcrumbPath(node);
-  const breadcrumbsEl = document.getElementById("breadcrumbs");
-  if (breadcrumbsEl) breadcrumbsEl.textContent = path;
-}
-
-docListRoot.addEventListener("click", (e) => {
-  const row = e.target.closest(".tree-row");
-  if (!row) return;
-
-  const node = row.closest(".tree-node");
-  const pid = node.dataset.pageId;
-  if (pid) showPage(pid, node);
-});
-
-const starBtn = document.getElementById("starBtn");
-const img = starBtn.querySelector("img");
-
-starBtn.addEventListener("click", () => {
-  img.src = img.src.includes("star-icon.svg")
-    ? "./assets/icons/star-fill-icon.svg"
-    : "./assets/icons/star-icon.svg";
-});
-
-const titleInput = document.getElementById("titleInput");
-
-function autoResize(el) {
-  el.style.height = "auto";
-  el.style.height = el.scrollHeight + "px";
-}
-
-// 헤더 타이틀 입력 시 높이 자동 조정
-titleInput.addEventListener("input", () => autoResize(titleInput));
-
-// 초기 로드 시에도 높이 맞춤
-window.addEventListener("load", () => autoResize(titleInput));
-
-const ICON_DEFAULT_SRC = "./assets/icons/page-default-icon.svg";
-
-function ensureIconFields(page) {
-  if (!("iconType" in page)) page.iconType = "image"; // 'image' | 'emoji'
-  if (!("iconValue" in page)) page.iconValue = ICON_DEFAULT_SRC; // img src or emoji char
-}
-
-const iconBtn = document.getElementById("iconBtn");
-
-function renderHeaderIcon(type, value) {
-  if (type === "emoji") {
-    iconBtn.innerHTML = `<span class="doc-emoji" aria-hidden="true">${value}</span>`;
-  } else {
-    const src = value || ICON_DEFAULT_SRC;
-    iconBtn.innerHTML = `<img src="${src}" alt="기본 페이지 아이콘" />`;
-  }
-}
-
-function updateSidebarIcon(pageId, type, value) {
-  const node = document.querySelector(`.tree-node[data-page-id="${pageId}"]`);
-  if (!node) return;
-
-  const iconHost = node.querySelector(".doc-icon");
-  if (!iconHost) return;
-
-  if (type === "emoji") {
-    iconHost.innerHTML = `<span class="doc-icon-emoji" aria-hidden="true">${value}</span>`;
-  } else {
-    const src = value || ICON_DEFAULT_SRC;
-    iconHost.innerHTML = `<img src="${src}" alt="기본 페이지 아이콘" />`;
-  }
-}
-
-// 모듈 스코프에서는 전역 UMD를 window로 접근
-const { createPopup } = window.picmoPopup || {};
-if (!createPopup) {
-  console.error("picmoPopup 로드 실패");
-}
+// 네비바/사이드바 초기화
+import { initNavbar } from "./navbar.js";
+import { initSidebar } from "./sidebar.js";
 
 document.addEventListener("DOMContentLoaded", () => {
-  const btn = document.getElementById("iconBtn");
-  if (!btn) return;
+  // 네비바가 showPage 콜백을 리턴함
+  const showPage = initNavbar({ appState, ICONS });
 
-  // 현재 활성 페이지 정보 확보
-  const getActivePage = () => pages?.get?.(activePageId);
-
-  {
-    const page = getActivePage();
-    if (page) {
-      ensureIconFields(page);
-      renderHeaderIcon(page.iconType, page.iconValue);
-    } else {
-      renderHeaderIcon("image", ICON_DEFAULT_SRC);
-    }
-  }
-
-  // PicMo 팝업 생성
-  const picker = createPopup(
-    { rootElement: document.body, showPreview: false, animate: true },
-    { referenceElement: btn, triggerElement: btn, position: "bottom-start" }
-  );
-
-  btn.addEventListener("click", () => picker.toggle());
-
-  // 이모지 선택 → 상태 저장 → 헤더/사이드바 동기화
-  picker.addEventListener("emoji:select", (e) => {
-    const page = getActivePage();
-    const emoji = e.emoji;
-
-    if (page) {
-      ensureIconFields(page);
-      page.iconType = "emoji";
-      page.iconValue = emoji;
-      renderHeaderIcon("emoji", emoji);
-      updateSidebarIcon(page.id, "emoji", emoji);
-    } else {
-      renderHeaderIcon("emoji", emoji);
-    }
+  // 사이드바에 showPage 전달
+  initSidebar({
+    appState,
+    ICONS,
+    STORAGE_KEYS,
+    SIDEBAR,
+    showPage,
+    createPageData,
+    ensureIconFields,
+    getPage,
+    getActivePageId,
   });
 });

--- a/ARI/clone_notion/scripts/main.js
+++ b/ARI/clone_notion/scripts/main.js
@@ -1,3 +1,7 @@
+import { initNavbar } from "./navbar.js";
+import { initSidebar } from "./sidebar.js";
+import "./editor.js";
+
 // 공용 상수 & 상태
 const STORAGE_KEYS = { SIDEBAR_WIDTH: "notionClone:sidebar-width" };
 const ICONS = {
@@ -36,10 +40,6 @@ export function getActivePageId() {
 export function setActivePageId(id) {
   appState.activePageId = id;
 }
-
-// 네비바/사이드바 초기화
-import { initNavbar } from "./navbar.js";
-import { initSidebar } from "./sidebar.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   // 네비바가 showPage 콜백을 리턴함

--- a/ARI/clone_notion/scripts/main.js
+++ b/ARI/clone_notion/scripts/main.js
@@ -47,7 +47,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 사이드바에 showPage 전달
   initSidebar({
-    appState,
     ICONS,
     STORAGE_KEYS,
     SIDEBAR,

--- a/ARI/clone_notion/scripts/navbar.js
+++ b/ARI/clone_notion/scripts/navbar.js
@@ -92,12 +92,12 @@ export function initNavbar({ appState, ICONS }) {
   // 타이틀 실시간 동기화
   titleInput?.addEventListener("input", () => {
     autoResize(titleInput);
-    const pid = getActivePageId();
-    const page = getPage(pid);
+    const pageId = getActivePageId();
+    const page = getPage(pageId);
     if (!page) return;
     const newTitle = (titleInput.value || "").trim() || "제목 없음";
     page.title = newTitle;
-    const node = document.querySelector(`.tree-node[data-page-id="${pid}"]`);
+    const node = document.querySelector(`.tree-node[data-page-id="${pageId}"]`);
     const titleEl = node?.querySelector(":scope > .tree-row .doc-title");
     if (titleEl) titleEl.textContent = newTitle;
     updateBreadcrumbsFromActive();
@@ -124,8 +124,8 @@ export function initNavbar({ appState, ICONS }) {
     );
     iconBtn.addEventListener("click", () => picker.toggle());
     picker.addEventListener("emoji:select", (e) => {
-      const pid = getActivePageId();
-      const page = getPage(pid);
+      const pageId = getActivePageId();
+      const page = getPage(pageId);
       const emoji = e.emoji;
 
       if (page) {
@@ -142,8 +142,8 @@ export function initNavbar({ appState, ICONS }) {
 
   // 초기 아이콘 렌더
   (function initIcon() {
-    const pid = getActivePageId();
-    const page = pid && getPage(pid);
+    const pageId = getActivePageId();
+    const page = pageId && getPage(pageId);
     if (page) {
       ensureIconFields(page);
       renderHeaderIcon(page.iconType, page.iconValue);

--- a/ARI/clone_notion/scripts/navbar.js
+++ b/ARI/clone_notion/scripts/navbar.js
@@ -1,0 +1,156 @@
+import {
+  ensureIconFields,
+  getPage,
+  getActivePageId,
+  setActivePageId,
+} from "./main.js";
+
+export function initNavbar({ appState, ICONS }) {
+  const titleInput = document.getElementById("titleInput");
+  const breadcrumbsEl = document.getElementById("breadcrumbs");
+  const starBtn = document.getElementById("starBtn");
+  const starImg = starBtn?.querySelector("img");
+  const iconBtn = document.getElementById("iconBtn");
+
+  function autoResize(el) {
+    el.style.height = "auto";
+    el.style.height = el.scrollHeight + "px";
+  }
+
+  function renderHeaderIcon(type, value) {
+    if (type === "emoji") {
+      iconBtn.innerHTML = `<span class="doc-emoji" aria-hidden="true">${value}</span>`;
+    } else {
+      const src = value || ICONS.defaultPage;
+      iconBtn.innerHTML = `<img src="${src}" alt="기본 페이지 아이콘" />`;
+    }
+  }
+  function updateSidebarIcon(pageId, type, value) {
+    const node = document.querySelector(`.tree-node[data-page-id="${pageId}"]`);
+    if (!node) return;
+    const host = node.querySelector(".doc-icon");
+    if (!host) return;
+    if (type === "emoji") {
+      host.innerHTML = `<span class="doc-icon-emoji" aria-hidden="true">${value}</span>`;
+    } else {
+      const src = value || ICONS.defaultPage;
+      host.innerHTML = `<img src="${src}" alt="기본 페이지 아이콘" />`;
+    }
+  }
+
+  function getActiveNode() {
+    return (
+      document.querySelector(".tree-node.is-active") ||
+      (appState.activePageId &&
+        document.querySelector(
+          `.tree-node[data-page-id="${appState.activePageId}"]`
+        ))
+    );
+  }
+  function getBreadcrumbPath(node) {
+    const path = [];
+    let current = node;
+    while (current) {
+      const titleEl = current.querySelector(":scope > .tree-row .doc-title");
+      if (titleEl) path.unshift(titleEl.textContent.trim());
+      current = current.closest(".tree-children")?.closest(".tree-node");
+    }
+    return path.join(" / ");
+  }
+  function updateBreadcrumbsFromActive() {
+    const node = getActiveNode();
+    if (!node) return;
+    const path = getBreadcrumbPath(node);
+    if (breadcrumbsEl) breadcrumbsEl.textContent = path;
+  }
+
+  // showPage: 사이드바에서 import 없이 호출하도록 여기서 제공
+  function showPage(pageId, node) {
+    const page = getPage(pageId);
+    if (!page) return;
+
+    setActivePageId(pageId);
+
+    if (titleInput) {
+      titleInput.value = page.title;
+      autoResize(titleInput);
+    }
+    ensureIconFields(page);
+    renderHeaderIcon(page.iconType, page.iconValue);
+
+    if (node) {
+      // active 표시
+      document
+        .querySelectorAll(".tree-node.is-active")
+        .forEach((n) => n.classList.remove("is-active"));
+      node.classList.add("is-active");
+    }
+
+    updateBreadcrumbsFromActive();
+  }
+
+  // 타이틀 실시간 동기화
+  titleInput?.addEventListener("input", () => {
+    autoResize(titleInput);
+    const pid = getActivePageId();
+    const page = getPage(pid);
+    if (!page) return;
+    const newTitle = (titleInput.value || "").trim() || "제목 없음";
+    page.title = newTitle;
+    const node = document.querySelector(`.tree-node[data-page-id="${pid}"]`);
+    const titleEl = node?.querySelector(":scope > .tree-row .doc-title");
+    if (titleEl) titleEl.textContent = newTitle;
+    updateBreadcrumbsFromActive();
+  });
+  window.addEventListener("load", () => titleInput && autoResize(titleInput));
+
+  // 즐겨찾기 토글
+  starBtn?.addEventListener("click", () => {
+    const isStar = starImg.src.includes("star-icon.svg");
+    starImg.src = isStar ? ICONS.starFill : ICONS.star;
+  });
+
+  // PicMo 연결
+  const { createPopup } = window.picmoPopup || {};
+  if (!createPopup) console.error("picmoPopup 로드 실패");
+  if (iconBtn && createPopup) {
+    const picker = createPopup(
+      { rootElement: document.body, showPreview: false, animate: true },
+      {
+        referenceElement: iconBtn,
+        triggerElement: iconBtn,
+        position: "bottom-start",
+      }
+    );
+    iconBtn.addEventListener("click", () => picker.toggle());
+    picker.addEventListener("emoji:select", (e) => {
+      const pid = getActivePageId();
+      const page = getPage(pid);
+      const emoji = e.emoji;
+
+      if (page) {
+        ensureIconFields(page);
+        page.iconType = "emoji";
+        page.iconValue = emoji;
+        renderHeaderIcon("emoji", emoji);
+        updateSidebarIcon(page.id, "emoji", emoji);
+      } else {
+        renderHeaderIcon("emoji", emoji);
+      }
+    });
+  }
+
+  // 초기 아이콘 렌더
+  (function initIcon() {
+    const pid = getActivePageId();
+    const page = pid && getPage(pid);
+    if (page) {
+      ensureIconFields(page);
+      renderHeaderIcon(page.iconType, page.iconValue);
+    } else {
+      renderHeaderIcon("image", ICONS.defaultPage);
+    }
+  })();
+
+  return showPage; // 사이드바에서 사용할 콜백
+}

--- a/ARI/clone_notion/scripts/sidebar.js
+++ b/ARI/clone_notion/scripts/sidebar.js
@@ -1,5 +1,4 @@
 export function initSidebar({
-  appState,
   ICONS,
   STORAGE_KEYS,
   SIDEBAR,
@@ -13,7 +12,6 @@ export function initSidebar({
   const collapseBtn = document.querySelector("#collapseBtn");
   const expandBtn = document.querySelector("#expandBtn");
   const root = document.documentElement;
-  const sidebar = document.querySelector("#sidebar");
   const handle = document.querySelector("#resizeHandle");
   const docListRoot = document.getElementById("docListRoot");
   const addPageBtn = document.getElementById("actionAddPage");
@@ -193,8 +191,8 @@ export function initSidebar({
 
     // 행 클릭 → 페이지 표시
     if (btn.classList.contains("tree-row")) {
-      const pid = node.dataset.pageId;
-      if (pid) showPage(pid, node);
+      const pageId = node.dataset.pageId;
+      if (pageId) showPage(pageId, node);
       return;
     }
 
@@ -218,12 +216,12 @@ export function initSidebar({
         newTitleEl.textContent = newTitle;
         input.replaceWith(newTitleEl);
 
-        const pid = node.dataset.pageId;
-        const page = getPage(pid);
+        const pageId = node.dataset.pageId;
+        const page = getPage(pageId);
         if (page) page.title = newTitle;
 
         // 활성 페이지면 헤더도 동기화(네비바 input에 반영)
-        if (getActivePageId() === pid) {
+        if (getActivePageId() === pageId) {
           const titleInput = document.getElementById("titleInput");
           if (titleInput) {
             titleInput.value = newTitle;
@@ -236,7 +234,7 @@ export function initSidebar({
         const breadcrumbsEl = document.getElementById("breadcrumbs");
         if (breadcrumbsEl) {
           // showPage를 다시 호출하면 네비바 갱신 로직을 재사용
-          showPage(getActivePageId() || pid, node);
+          showPage(getActivePageId() || pageId, node);
         }
       };
 

--- a/ARI/clone_notion/scripts/sidebar.js
+++ b/ARI/clone_notion/scripts/sidebar.js
@@ -1,0 +1,253 @@
+export function initSidebar({
+  appState,
+  ICONS,
+  STORAGE_KEYS,
+  SIDEBAR,
+  showPage,
+  createPageData,
+  ensureIconFields,
+  getPage,
+  getActivePageId,
+}) {
+  const app = document.querySelector(".app");
+  const collapseBtn = document.querySelector("#collapseBtn");
+  const expandBtn = document.querySelector("#expandBtn");
+  const root = document.documentElement;
+  const sidebar = document.querySelector("#sidebar");
+  const handle = document.querySelector("#resizeHandle");
+  const docListRoot = document.getElementById("docListRoot");
+  const addPageBtn = document.getElementById("actionAddPage");
+
+  // 접기/펼치기
+  const sidebarCollapsed = (on) => {
+    app.classList.toggle("is-collapsed", on);
+    expandBtn.setAttribute("aria-expanded", !on);
+    collapseBtn.setAttribute("aria-expanded", !on);
+  };
+  collapseBtn?.addEventListener("click", () => sidebarCollapsed(true));
+  expandBtn?.addEventListener("click", () => sidebarCollapsed(false));
+
+  // 리사이즈 복원
+  const DEFAULT_W = getComputedStyle(root)
+    .getPropertyValue(SIDEBAR.CSS_VAR)
+    .trim();
+  const savedWidth = localStorage.getItem(STORAGE_KEYS.SIDEBAR_WIDTH);
+  if (savedWidth) root.style.setProperty(SIDEBAR.CSS_VAR, savedWidth);
+
+  // 리사이즈 드래그
+  let isResizing = false;
+  let newWidth;
+  function onDown(e) {
+    isResizing = true;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "ew-resize";
+    e.preventDefault();
+  }
+  function onMove(e) {
+    if (!isResizing) return;
+    const n = Math.min(SIDEBAR.MAX_W, Math.max(SIDEBAR.MIN_W, e.clientX));
+    newWidth = n;
+    root.style.setProperty(SIDEBAR.CSS_VAR, `${n}px`);
+  }
+  function onUp() {
+    if (!isResizing) return;
+    isResizing = false;
+    document.body.style.userSelect = "";
+    document.body.style.cursor = "";
+    if (newWidth != null)
+      localStorage.setItem(STORAGE_KEYS.SIDEBAR_WIDTH, `${newWidth}px`);
+  }
+  handle?.addEventListener("dblclick", () => {
+    root.style.setProperty(SIDEBAR.CSS_VAR, DEFAULT_W);
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_WIDTH, DEFAULT_W);
+  });
+  handle?.addEventListener("mousedown", onDown);
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mouseup", onUp);
+
+  // 트리 생성
+  function setActiveNode(node) {
+    docListRoot
+      .querySelectorAll(".tree-node.is-active")
+      .forEach((n) => n.classList.remove("is-active"));
+    node.classList.add("is-active");
+  }
+  function createTreeNode(
+    titleOrPage = "새 페이지",
+    depth = 0,
+    parentId = null
+  ) {
+    const page =
+      typeof titleOrPage === "string"
+        ? createPageData(titleOrPage, parentId)
+        : titleOrPage;
+    ensureIconFields(page);
+    const iconHtml =
+      page.iconType === "emoji"
+        ? `<span class="doc-icon-emoji" aria-hidden="true">${page.iconValue}</span>`
+        : `<img src="${
+            page.iconValue || ICONS.defaultPage
+          }" alt="기본 페이지 아이콘" />`;
+
+    const node = document.createElement("div");
+    node.className = "tree-node";
+    node.dataset.depth = depth;
+    node.dataset.pageId = page.id;
+    node.style.setProperty("--indent", depth);
+    node.innerHTML = `
+      <div class="tree-row">
+        <div class="doc-slot">
+          <div class="doc-icon">${iconHtml}</div>
+          <button class="chevron" type="button" aria-label="하위 페이지 토글" data-action="toggle">
+            <img src="${ICONS.close}" alt="접기" />
+          </button>
+        </div>
+        <div class="doc-title">${page.title}</div>
+        <div class="tree-actions">
+          <button class="ghost" type="button" aria-label="더보기" data-action="more">
+            <img src="./assets/icons/ellipsis-small-icon.svg" alt="더보기" />
+          </button>
+          <button class="ghost" type="button" aria-label="하위 페이지 추가" data-action="add-child">
+            <img src="./assets/icons/plus-small-icon.svg" alt="하위 페이지 추가" />
+          </button>
+          <div class="dropdown-menu">
+            <div class="dropdown-list">
+              <button class="dropdown-item" type="button" data-menu="duplicate">
+                <img src="./assets/icons/star-icon.svg" alt="즐겨찾기" />즐겨찾기에 추가
+              </button>
+              <button class="dropdown-item" type="button" data-menu="rename">
+                <img src="./assets/icons/rename-icon.svg" alt="이름 변경" />이름 바꾸기
+              </button>
+              <button class="dropdown-item" type="button" data-menu="delete">
+                <img src="./assets/icons/trash-icon.svg" alt="휴지통" />휴지통으로 이동
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="tree-children"></div>
+    `;
+    return node;
+  }
+
+  // 페이지 추가 버튼
+  addPageBtn?.addEventListener("click", () => {
+    const page = createPageData("새 페이지");
+    const node = createTreeNode(page, 0);
+    docListRoot.appendChild(node);
+    showPage(page.id, node);
+  });
+
+  // 드롭다운 열림 상태 관리
+  function closeDropdown() {
+    docListRoot
+      .querySelectorAll(".dropdown-menu.is-open")
+      .forEach((el) => el.classList.remove("is-open"));
+  }
+  document.addEventListener("click", (e) => {
+    if (e.target.closest(".dropdown-menu, [data-action='more']")) return;
+    closeDropdown();
+  });
+
+  // 트리 이벤트 위임
+  docListRoot.addEventListener("click", (e) => {
+    const btn = e.target.closest(
+      "[data-action], .chevron, [data-menu], .tree-row"
+    );
+    if (!btn) return;
+
+    const node = btn.closest(".tree-node");
+    if (!node) return;
+
+    const children = node.querySelector(":scope > .tree-children");
+    const chevronImg = node.querySelector(":scope > .tree-row .chevron img");
+
+    const action = btn.dataset.action;
+    const menuAction = btn.dataset.menu;
+
+    if (action === "add-child") {
+      const depth = (parseInt(node.dataset.depth, 10) || 0) + 1;
+      const parentId = node.dataset.pageId;
+      const childPage = createPageData("새 페이지", parentId);
+      const childNode = createTreeNode(childPage, depth, parentId);
+      children.appendChild(childNode);
+      node.classList.add("is-open");
+      chevronImg.src = ICONS.open;
+      chevronImg.alt = "펼치기";
+      return;
+    }
+
+    if (action === "toggle") {
+      const isOpen = node.classList.toggle("is-open");
+      chevronImg.src = isOpen ? ICONS.open : ICONS.close;
+      chevronImg.alt = isOpen ? "펼치기" : "접기";
+      return;
+    }
+
+    if (action === "more") {
+      const actions = node.querySelector(":scope > .tree-row .tree-actions");
+      const menu = actions.querySelector(":scope > .dropdown-menu");
+      menu.classList.toggle("is-open");
+      return;
+    }
+
+    // 행 클릭 → 페이지 표시
+    if (btn.classList.contains("tree-row")) {
+      const pid = node.dataset.pageId;
+      if (pid) showPage(pid, node);
+      return;
+    }
+
+    // 드롭다운: 이름 변경
+    if (menuAction === "rename") {
+      closeDropdown();
+      const titleEl = node.querySelector(":scope > .tree-row .doc-title");
+      const oldTitle = titleEl.textContent;
+
+      const input = document.createElement("input");
+      input.type = "text";
+      input.value = oldTitle;
+      input.className = "rename-input";
+      titleEl.replaceWith(input);
+      input.focus();
+
+      const saveRename = () => {
+        const newTitle = input.value.trim() || oldTitle;
+        const newTitleEl = document.createElement("div");
+        newTitleEl.className = "doc-title";
+        newTitleEl.textContent = newTitle;
+        input.replaceWith(newTitleEl);
+
+        const pid = node.dataset.pageId;
+        const page = getPage(pid);
+        if (page) page.title = newTitle;
+
+        // 활성 페이지면 헤더도 동기화(네비바 input에 반영)
+        if (getActivePageId() === pid) {
+          const titleInput = document.getElementById("titleInput");
+          if (titleInput) {
+            titleInput.value = newTitle;
+            const evt = new Event("input");
+            titleInput.dispatchEvent(evt);
+          }
+        }
+
+        // 브레드크럼 텍스트 갱신 (네비바에서 계산)
+        const breadcrumbsEl = document.getElementById("breadcrumbs");
+        if (breadcrumbsEl) {
+          // showPage를 다시 호출하면 네비바 갱신 로직을 재사용
+          showPage(getActivePageId() || pid, node);
+        }
+      };
+
+      input.addEventListener("blur", saveRename, { once: true });
+      input.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter") input.blur();
+        if (ev.key === "Escape") {
+          input.value = oldTitle;
+          input.blur();
+        }
+      });
+    }
+  });
+}

--- a/ARI/clone_notion/styles/main.css
+++ b/ARI/clone_notion/styles/main.css
@@ -310,9 +310,9 @@ main {
   overflow: auto;
 }
 .doc-canvas {
+  position: relative;
   max-width: 800px;
-  margin: 0 auto 30vh;
-  padding: 20px;
+  margin: 0 auto 80px;
 }
 
 .doc-header {
@@ -371,13 +371,51 @@ main {
 }
 
 .toolbar {
-  width: 80%;
-  height: 40px;
-  background-color: var(--panel-3);
+  position: sticky;
+  top: 15px;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  border: 1px solid var(--border);
+  padding: 6px;
+}
+.tbtn {
+  padding: 6px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  color: var(--muted);
+}
+.tbtn:hover {
+  background: var(--panel-3);
+  color: var(--text);
+}
+.sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
 }
 
 .editor {
-  width: 80%;
-  height: 500px;
-  background-color: var(--panel-3);
+  margin-top: 30px;
+  min-height: 400px;
+}
+.editor:focus {
+  outline: none;
+}
+.editor pre {
+  background: #0f1220;
+  color: #e1e8ff;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid var(--md-border);
+  overflow: auto;
+}
+.editor blockquote {
+  border-left: 4px solid var(--md-border);
+  margin: 8px 0;
+  padding: 6px 10px;
+  color: var(--muted);
+  background: color-mix(in oklab, var(--panel) 92%, transparent);
+  border-radius: 10px;
 }


### PR DESCRIPTION
## 구현내용
- editor 영역 레이아웃 추가  
- toolbar 버튼 이벤트 및 기능 구현 (bold, italic, underline, heading, list, todo 등)  

## 상세 설명
<img width="869" height="742" alt="image" src="https://github.com/user-attachments/assets/f3844562-a601-4c29-870e-952622eb4690" />

- `editor.js` 파일을 분리하여 에디터와 툴바 관련 로직을 모듈화
- toolbar 버튼 클릭 시 `document.execCommand`를 활용하여 텍스트 서식 및 블록 변경 가능 

## 궁금한점
To-do 기능을 단순 삽입이 아니라 Notion처럼 block 단위 관리 구조로 가져가야 할지 고민 중

## 느낀점
 기본 서식 기능은 `execCommand`로 빠르게 구현할 수 있었지만, 확장성에는 한계가 있어 대체 방안도 찾아볼 필요가 있다고 생각했습니다.
